### PR TITLE
Add basic node test suite setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ This repository hosts the code for Niru Maheswaranathan's website built with Nex
 - Install dependencies with `npm install` if you have not done so.
 - Use `npm run dev` for local development.
 - Use `npm run build` to ensure the production build succeeds before committing any code changes.
+- Run unit tests with `npm test` (or `just test`).
 
 ## Style Guidelines
 - Use 2-space indentation and single quotes for strings.
 - Prefer named exports for components and arrow functions for inner components.
 - Follow the React and Tailwind conventions outlined in `CLAUDE.md`.
-

--- a/justfile
+++ b/justfile
@@ -11,5 +11,10 @@ build:
   npm run build
   echo 'Done!'
 
+test:
+  echo 'Running unit tests...'
+  npm test
+  echo 'Done!'
+
 sloc:
   @echo "`wc -l **/*.js` lines of code"

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
-module.exports = {
+const nextConfig = {
   trailingSlash: true,
-  output: "export",
-};
+  output: 'export',
+}
+
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "description": "Niru's personal website",
   "version": "0.5.1",
+  "type": "module",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "export": "next export"
+    "export": "next export",
+    "test": "node --test"
   },
   "dependencies": {
     "date-fns": "^3.6.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,7 @@
-module.exports = {
+const config = {
   plugins: {
     '@tailwindcss/postcss': {},
   },
 }
+
+export default config

--- a/tests/metadata.test.mjs
+++ b/tests/metadata.test.mjs
@@ -1,0 +1,17 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { hrefs, repositories } from '../components/metadata.js'
+
+test('hrefs include primary profiles', () => {
+  const expected = ['email', 'github', 'pinboard', 'scholar', 'twitter']
+  assert.deepEqual(
+    Object.keys(hrefs).sort(),
+    expected.sort(),
+    'hrefs should expose all expected keys',
+  )
+})
+
+test('repositories list is not empty', () => {
+  assert.ok(Array.isArray(repositories), 'repositories should be an array')
+  assert.ok(repositories.length > 0, 'repositories should include entries')
+})


### PR DESCRIPTION
## Summary
- enable ESM package configuration and adjust Next/PostCSS configs accordingly
- add `npm test` script plus `just test` helper and document test workflow in AGENTS.md
- add an example metadata unit test using the built-in `node:test` runner

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959aa3a89788325ab5a793fa998da09)