### PR TITLE
Add utility helpers and unit tests

### DIFF
--- a/components/pub-card.js
+++ b/components/pub-card.js
@@ -1,13 +1,4 @@
-import Link from "next/link";
-import { join } from "path";
-
-function formatDate(dateString) {
-  let d = new Date(dateString);
-  let day = d.getDate();
-  let month = d.getMonth() + 1;
-  let year = d.getFullYear();
-  return year;
-}
+import { formatDate } from '../lib/utils.js';
 
 export const Library = ({ size }) => (
   <svg

--- a/lib/publications.js
+++ b/lib/publications.js
@@ -1,0 +1,4 @@
+import path from 'path';
+
+export const changeExtension = (file) =>
+  path.join('/pubs/', path.basename(file, path.extname(file)) + '.png');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,7 @@
+export const pluralize = (value, word, plural = word + 's') =>
+  value === 1 ? value + ' ' + word : value + ' ' + plural;
+
+export const formatDate = (dateString) => {
+  const d = new Date(dateString);
+  return d.getFullYear();
+};

--- a/pages/code.js
+++ b/pages/code.js
@@ -1,10 +1,8 @@
-import fetch from "node-fetch";
-import { repositories } from "../components/metadata";
-import path from "path";
-import { emojify } from "node-emoji";
-
-const pluralize = (value, word, plural = word + "s") =>
-  value === 1 ? value + " " + word : value + " " + plural;
+import fetch from 'node-fetch';
+import { repositories } from '../components/metadata';
+import path from 'path';
+import { emojify } from 'node-emoji';
+import { pluralize } from '../lib/utils.js';
 
 const GitHubBookmark = ({ size }) => (
   <svg

--- a/pages/research.js
+++ b/pages/research.js
@@ -1,39 +1,33 @@
-import React from "react";
-const yaml = require("js-yaml");
-import fs from "fs";
-import PubCard from "../components/pub-card";
-import { hrefs } from "../components/metadata";
-import path from "path";
-
-function changeExtension(file) {
-  return path.join("/pubs/", path.basename(file, path.extname(file)) + ".png");
-}
+import React from 'react';
+import yaml from 'js-yaml';
+import fs from 'fs';
+import PubCard from '../components/pub-card';
+import { hrefs } from '../components/metadata';
+import { changeExtension } from '../lib/publications.js';
 
 export const getStaticProps = async () => {
-  const filenames = fs.readdirSync("publications");
+  const filenames = fs.readdirSync('publications');
   const data = [];
   const parse = (o) => {
     o.date = o.date.toJSON();
     return o;
   };
   filenames.forEach((filename) => {
-    let file = fs.readFileSync("publications/" + filename, "utf-8");
-    let obj = yaml.load(file);
+    const file = fs.readFileSync('publications/' + filename, 'utf-8');
+    const obj = yaml.load(file);
     obj.image = changeExtension(filename);
     data.push(parse(obj));
   });
   // sort by name
-  data.sort(function (a, b) {
-    var nameA = new Date(a.date);
-    var nameB = new Date(b.date);
+  data.sort((a, b) => {
+    const nameA = new Date(a.date);
+    const nameB = new Date(b.date);
     if (nameA < nameB) {
       return 1;
     }
     if (nameA > nameB) {
       return -1;
     }
-
-    // names must be equal
     return 0;
   });
   return {

--- a/tests/pluralize.test.mjs
+++ b/tests/pluralize.test.mjs
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { pluralize } from '../lib/utils.js';
+
+test('pluralize uses singular form for value of one', () => {
+  assert.equal(pluralize(1, 'star'), '1 star');
+});
+
+test('pluralize defaults to plural form otherwise', () => {
+  assert.equal(pluralize(2, 'star'), '2 stars');
+  assert.equal(pluralize(0, 'star'), '0 stars');
+});
+
+test('pluralize accepts custom plural values', () => {
+  assert.equal(pluralize(3, 'repository', 'repositories'), '3 repositories');
+});

--- a/tests/pub-card.test.mjs
+++ b/tests/pub-card.test.mjs
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDate } from '../lib/utils.js';
+
+test('formatDate returns the year from an ISO date string', () => {
+  assert.equal(formatDate('2024-02-29'), 2024);
+});
+
+test('formatDate accepts Date instances by coercing to string', () => {
+  assert.equal(formatDate(new Date('2018-07-15')), 2018);
+});

--- a/tests/research.test.mjs
+++ b/tests/research.test.mjs
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { changeExtension } from '../lib/publications.js';
+
+test('changeExtension swaps extension with png and prefixes pubs directory', () => {
+  assert.equal(changeExtension('deep-retina-v1.yml'), '/pubs/deep-retina-v1.png');
+});
+
+test('changeExtension handles nested paths by stripping directories', () => {
+  assert.equal(changeExtension('papers/notes/integration-geometry.yaml'), '/pubs/integration-geometry.png');
+});


### PR DESCRIPTION
## Summary
- add shared utility helpers for pluralization, date formatting, and publication asset paths
- update components and pages to use the new helpers
- add unit tests covering the helper functions

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ae213ea88325a8c2f564e9e46202)