### PR TITLE
Add blog page with markdown posts

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -36,13 +36,6 @@ const ThemeToggle = ({ theme, onToggleTheme }) => {
   );
 };
 
-// (removed blog link)
-// <li>
-//   <ActiveLink href="/blog" activeClassName={active}>
-//     <div className={inactive}>Blog</div>
-//   </ActiveLink>
-// </li>
-
 export default function Header({ theme, onToggleTheme }) {
   const active =
     "text-indigo-600 dark:text-cyan-500 border-b-2 dark:border-cyan-700 border-indigo-400";
@@ -67,6 +60,11 @@ export default function Header({ theme, onToggleTheme }) {
         <li>
           <ActiveLink href="/code" activeClassName={active}>
             <div className={inactive}>Code</div>
+          </ActiveLink>
+        </li>
+        <li>
+          <ActiveLink href="/blog" activeClassName={active}>
+            <div className={inactive}>Blog</div>
           </ActiveLink>
         </li>
         <li className='ml-4 flex items-center'>

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -1,0 +1,56 @@
+import React from "react";
+import fs from "fs";
+import matter from "gray-matter";
+import { remark } from "remark";
+import html from "remark-html";
+import Link from "next/link";
+import { format } from "date-fns";
+
+export const getStaticPaths = async () => {
+  const filenames = fs.readdirSync("posts").filter((f) => f.endsWith(".md"));
+  const paths = [];
+
+  filenames.forEach((filename) => {
+    const file = fs.readFileSync("posts/" + filename, "utf-8");
+    const { data } = matter(file);
+    const tags = data.tags || [];
+    if (!tags.includes("draft")) {
+      paths.push({ params: { slug: filename.replace(".md", "") } });
+    }
+  });
+
+  return { paths, fallback: false };
+};
+
+export const getStaticProps = async ({ params }) => {
+  const file = fs.readFileSync("posts/" + params.slug + ".md", "utf-8");
+  const { data, content } = matter(file);
+
+  const result = await remark().use(html).process(content);
+
+  return {
+    props: {
+      title: data.title,
+      date: data.date.toString(),
+      content: result.toString(),
+    },
+  };
+};
+
+export default function BlogPost({ title, date, content }) {
+  return (
+    <div>
+      <Link
+        href="/blog"
+        className="dim-color text-sm font-sans hover:text-indigo-600 dark:hover:text-cyan-500"
+      >
+        &larr; Back to blog
+      </Link>
+      <h1>{title}</h1>
+      <p className="dim-color font-sans text-sm sm:text-base !mt-2">
+        {format(new Date(date), "MMMM d, yyyy")}
+      </p>
+      <article dangerouslySetInnerHTML={{ __html: content }} />
+    </div>
+  );
+}

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -12,7 +12,6 @@ export const getStaticProps = async () => {
     let file = fs.readFileSync("posts/" + filename, "utf-8");
     const { data } = matter(file);
     const tags = data.tags || [];
-    console.log(tags.includes("draft"));
     if (!tags.includes("draft")) {
       data["slug"] = filename.replace(".md", "");
       data["date"] = data["date"].toString();
@@ -33,6 +32,9 @@ export default function BlogPage({ posts }) {
     <div>
       <h1>Blog posts</h1>
       <div className="mt-8 flex flex-col space-y-4 mt-12 mx-auto">
+        {posts.length === 0 && (
+          <p className="dim-color font-sans">No posts yet.</p>
+        )}
         {posts.map((p, i) => (
           <div key={i} className="font-sans w-full">
             <Link

--- a/posts/hello-world.md
+++ b/posts/hello-world.md
@@ -1,0 +1,38 @@
+---
+title: Hello, World
+date: 2026-03-28
+tags: []
+---
+
+This is a sample blog post to test out the blog functionality. Feel free to delete this post and replace it with your own content.
+
+## A heading
+
+Here is some text under a heading. You can write paragraphs with **bold**, *italic*, and `inline code` formatting.
+
+> This is a blockquote. It can be used to highlight important ideas or quotations.
+
+## Code
+
+Here is a code block:
+
+```python
+def hello():
+    print("Hello, world!")
+```
+
+## Images
+
+You can include images stored in the `public/blog/` directory:
+
+![Sample image](/blog/sample.png)
+
+## Lists
+
+- Item one
+- Item two
+- Item three
+
+1. First
+2. Second
+3. Third

--- a/posts/on-writing-good-code.md
+++ b/posts/on-writing-good-code.md
@@ -1,0 +1,27 @@
+---
+title: On Writing Good Code
+date: 2026-03-15
+tags: []
+---
+
+Good code is code that communicates its intent clearly. It's not about cleverness or brevity — it's about the next person who reads it being able to understand what's happening and why.
+
+## Readability over performance
+
+Most of the time, the bottleneck isn't your code — it's your ability to reason about it six months later. Optimize for clarity first.
+
+```javascript
+// Prefer this
+const activeUsers = users.filter(user => user.isActive);
+
+// Over this
+const a = u.filter(x => x.a);
+```
+
+## Names matter
+
+A well-named variable eliminates the need for a comment. If you find yourself writing a comment to explain *what* a variable holds, rename it instead.
+
+## Small functions
+
+Each function should do one thing. If you're scrolling to see the whole function, it's probably doing too much.

--- a/posts/tools-i-use.md
+++ b/posts/tools-i-use.md
@@ -1,0 +1,25 @@
+---
+title: Tools I Use
+date: 2026-03-22
+tags: []
+---
+
+I get asked about my setup frequently, so here's a quick rundown of the tools I reach for daily.
+
+## Editor
+
+I've been using Neovim for a few years now. The learning curve is steep, but the payoff in editing speed is real. My config is pretty minimal — just a handful of plugins for fuzzy finding, LSP, and Git integration.
+
+## Terminal
+
+I use [Kitty](https://sw.kovidgoyal.net/kitty/) as my terminal emulator. It's GPU-accelerated, configurable, and fast. Combined with `tmux`, it handles everything I need.
+
+## Languages
+
+Most of my work these days is in **Python** and **JavaScript/TypeScript**. Python for research and data work, TypeScript for web projects like this site.
+
+## Version control
+
+Git, obviously. I try to keep commits small and messages descriptive. A good commit history is a form of documentation.
+
+> The best tool is the one you know well enough to not think about.

--- a/posts/why-i-blog.md
+++ b/posts/why-i-blog.md
@@ -1,0 +1,25 @@
+---
+title: Why I Blog
+date: 2026-03-29
+tags: []
+---
+
+Writing is thinking made visible. I started this blog not because I have an audience, but because the act of writing forces me to clarify my own understanding.
+
+## Writing as learning
+
+When I try to explain something in prose, I quickly discover the gaps in my knowledge. The parts I hand-wave over in my head become obvious on the page. Writing a blog post about a topic is one of the best ways to actually learn it.
+
+## A public notebook
+
+I think of these posts as a public notebook. Some will be polished essays, others will be rough notes. That's fine — the goal isn't perfection, it's consistency.
+
+## Keeping it simple
+
+This blog is just markdown files in a Git repo. No CMS, no database, no analytics. I write in my editor, commit, and push. The fewer barriers between thinking and publishing, the more likely I am to actually do it.
+
+1. Write the post
+2. Commit and push
+3. That's it
+
+If you're thinking about starting a blog, my advice is: don't overthink it. Just start writing.


### PR DESCRIPTION
## Summary
- Add "Blog" tab to the site navigation header
- Create individual blog post page (`pages/blog/[slug].js`) that renders markdown via `remark` + `remark-html`, with frontmatter parsed by `gray-matter`
- Add 4 sample blog posts demonstrating headings, code blocks, blockquotes, lists, and image references
- Blog images stored flat in `public/blog/`, referenced as `![alt](/blog/filename.png)`
- Clean up blog index page (remove stray `console.log`, add empty-state message)

## Test plan
- [ ] `npm run dev` — verify "Blog" tab appears in the header
- [ ] Visit `/blog` — confirm all 4 posts are listed, sorted by date
- [ ] Click a post — confirm it renders with correct styling (headings, code blocks, blockquotes)
- [ ] Verify dark mode works on blog pages
- [ ] `npm run build` — confirm static export succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)